### PR TITLE
Улучшения main.typ

### DIFF
--- a/main.typ
+++ b/main.typ
@@ -15,7 +15,7 @@
     numbering += "1.1. "
   }
   for section in details.sections.sections {
-    heading(section, numbering: numbering)
+    heading(section, numbering: numbering, hanging-indent: 0pt)
     include strfmt("sections/{:02}.typ", i)
     pagebreak(weak: true)
     i += 1

--- a/main.typ
+++ b/main.typ
@@ -1,8 +1,8 @@
 #import "conf.typ": details, generateAll
 #import "@preview/oxifmt:1.0.0": strfmt
-#set page(numbering: "1")
 #set heading(numbering: "1.1")
 #generateAll()
+#set page(numbering: "1")
 
 #let i = 1
 

--- a/main.typ
+++ b/main.typ
@@ -15,7 +15,7 @@
     numbering += "1.1. "
   }
   for section in details.sections.sections {
-    heading(section, numbering: numbering, hanging-indent: 0pt)
+    heading(eval(section, mode: "markup"), numbering: numbering, hanging-indent: 0pt)
     include strfmt("sections/{:02}.typ", i)
     pagebreak(weak: true)
     i += 1


### PR DESCRIPTION
 - Исправил нумерацию страниц, чтобы включалась только после содержания
 - Убрал лишний отступ у заголовка в тексте
![image](https://github.com/user-attachments/assets/c361a410-b3c5-4222-a145-86a3bdda3479)
 - Добавил возможность добавлять математические и другие символы в заголовок
![Снимок экрана от 2025-06-13 21-32-35](https://github.com/user-attachments/assets/04b2df5f-8dce-40af-96e3-e410362c074f)
